### PR TITLE
Additional error information in the event of a COM error.

### DIFF
--- a/src/ole32core.cpp
+++ b/src/ole32core.cpp
@@ -383,13 +383,23 @@ HRESULT OCVariant::AutoWrap(int autoType, VARIANT *pvResult,
     dp.cNamedArgs = 1;
     dp.rgdispidNamedArgs = &dispidNamed;
   }
+  EXCEPINFO exceptInfo;
   // Make the call!
   hr = v.pdispVal->Invoke(dispID, IID_NULL,
-    LOCALE_USER_DEFAULT, autoType, &dp, pvResult, NULL, NULL); // or _SYSTEM_ ?
+    LOCALE_USER_DEFAULT, autoType, &dp, pvResult, &exceptInfo, NULL); // or _SYSTEM_ ?
   delete [] pArgs;
   if(FAILED(hr)){
-    ostringstream oss;
-    oss << hr << " [" << szName << "] = [" << dispID << "] ";
+
+	// Convert down to ANSI (for error message only)
+	char szErrSource[256];
+	WideCharToMultiByte(CP_ACP, 0, exceptInfo.bstrSource, -1, szErrSource, sizeof(szErrSource), NULL, NULL);
+	char szErrDescription[256];
+	WideCharToMultiByte(CP_ACP, 0, exceptInfo.bstrDescription, -1, szErrDescription, sizeof(szErrDescription), NULL, NULL);
+
+	ostringstream oss;
+    oss << hr << " [" << szName << "] = [" << dispID << "]\r\n";
+	oss << szErrSource << ": ";
+	oss << szErrDescription << "\r\n";
     oss << "(It always seems to be appeared at that time you mistake calling ";
     oss << "'obj.get { ocv->getProp() }' <-> 'obj.call { ocv->invoke() }'.) ";
     oss << "IDispatch::Invoke AutoWrap";

--- a/src/v8variant.cc
+++ b/src/v8variant.cc
@@ -88,9 +88,12 @@ std::string V8Variant::CreateStdStringMBCSfromUTF8(Handle<Value> v)
 
 OCVariant *V8Variant::CreateOCVariant(Handle<Value> v)
 {
+  if (v->IsNull()){
+		return new OCVariant();
+  }
+
   BEVERIFY(done, !v.IsEmpty());
   BEVERIFY(done, !v->IsUndefined());
-  BEVERIFY(done, !v->IsNull());
   BEVERIFY(done, !v->IsExternal());
   BEVERIFY(done, !v->IsNativeError());
   BEVERIFY(done, !v->IsFunction());


### PR DESCRIPTION
Example:

```
var win32ole = require('win32ole');
var db = win32ole.client.Dispatch('ADODB.Connection');
db.Provider = "Microsoft.Jet.OLEDB.4.0";
db.Open("nofile.mdb");
```

Output:

OLE error: [Open] -2147352567 [Open] = [10]
**Microsoft JET Database Engine: Could not find file 'D:\git\nodejsplay\nofile.mdb'.**
(It always seems to be appeared at that time you mistake calling'obj.get { ocv->getProp() }' <-> 'obj.call{ocv->invoke() }'.) IDispatch::Invoke AutoWrap() failed

TypeError: node_win32ole::V8Variant::OLEInvoke failed
    at Object.<anonymous> (D:\git\nodejsplay\test.js:4:4)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
        at node.js:901:3

This suggested patch may also help to address issue #5
